### PR TITLE
feat: adaptive font for section-title

### DIFF
--- a/blocks/about/__title/about__title.css
+++ b/blocks/about/__title/about__title.css
@@ -1,3 +1,0 @@
-.about__title {
-    margin-left: calc(100% * (360/1440));
-}

--- a/blocks/section-title/_place/section-title_place_about.css
+++ b/blocks/section-title/_place/section-title_place_about.css
@@ -1,0 +1,4 @@
+.section-title_place_about {
+  font-size: 40px;
+  margin-left: calc(100% * (360/1440));
+}

--- a/blocks/section-title/section-title.css
+++ b/blocks/section-title/section-title.css
@@ -3,8 +3,14 @@
   font-family: 'Neue Machina', Arial, Helvetica, sans-serif;
   font-style: normal;
   font-weight: 400;
-  font-size: 40px;
+  font-size: calc(28px + 12 * ((100vw - 414px)/(1440 - 414)));
   line-height: 40px;
   letter-spacing: -0.01em;
   margin: 0 362px;
+}
+
+@media screen and (min-width: 1440px) {
+  .section-title {
+    font-size: 40px;
+  }
 }

--- a/blocks/section-title/section-title.css
+++ b/blocks/section-title/section-title.css
@@ -4,9 +4,9 @@
   font-style: normal;
   font-weight: 400;
   font-size: calc(28px + 12 * ((100vw - 414px)/(1440 - 414)));
-  line-height: 40px;
+  line-height: 1;
   letter-spacing: -0.01em;
-  margin: 0 362px;
+  margin: 0 25%;
 }
 
 @media screen and (min-width: 1440px) {

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     </section>
     <!-- Лена -->
     <section class="about">
-        <h2 class="about__title section-title section-title_place_about">О проекте</h2>
+        <h2 class="section-title section-title_place_about">О проекте</h2>
         <p class="about__text section-text">
             За первый сезон проекта организаторы провели 17 мероприятий вместе с режиссёрами и актёрами московских театров: Театра.doc, Театрального Центра им. Вс. Мейерхольда, Гоголь-центра, Электротеатра «Станиславский», Ленкома.
         </p>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     </section>
     <!-- Лена -->
     <section class="about">
-        <h2 class="about__title section-title">О проекте</h2>
+        <h2 class="about__title section-title section-title_place_about">О проекте</h2>
         <p class="about__text section-text">
             За первый сезон проекта организаторы провели 17 мероприятий вместе с режиссёрами и актёрами московских театров: Театра.doc, Театрального Центра им. Вс. Мейерхольда, Гоголь-центра, Электротеатра «Станиславский», Ленкома.
         </p>

--- a/pages/index.css
+++ b/pages/index.css
@@ -5,6 +5,7 @@
 @import url(../blocks/page/page.css);
 
 @import url(../blocks/section-title/section-title.css);
+@import url(../blocks/section-title/_place/section-title_place_about.css);
 @import url(../blocks/section-title/_place/section-title_place_reference.css);
 @import url(../blocks/section-text/section-text.css);
 

--- a/pages/index.css
+++ b/pages/index.css
@@ -21,7 +21,6 @@
 
 /* about */
 @import url(../blocks/about/about.css);
-@import url(../blocks/about/__title/about__title.css);
 @import url(../blocks/about/__text/about__text.css);
 
 


### PR DESCRIPTION
Добавил адаптивный шрифт для блока section-title так, чтобы во всех блоках кроме about он уменьшался от 40 до 28 по мере сужения экрана от 1440 до 414. Стоит медиазапрос на запрет увеличения шрифта на разрешение свыше 1440. Другие блоки с текстом пока не трогал пока, в тч h1. Обратил внимание, что есть шрифты с одинаковыми размерами на всех разрешениях.